### PR TITLE
Fixed server crash when reward commands are empty or wrong

### DIFF
--- a/common/src/main/java/org/pokesplash/hunt/util/Utils.java
+++ b/common/src/main/java/org/pokesplash/hunt/util/Utils.java
@@ -309,6 +309,11 @@ public abstract class Utils {
 	}
 
 	public static void runCommands(ArrayList<String> commands, ServerPlayer player, Pokemon pokemon, double price) {
+		if (commands == null) {
+			Hunt.LOGGER.error("Commands are null");
+			return;
+		}
+
 		// Run commands
 		CommandDispatcher<CommandSourceStack> dispatcher =
 				Hunt.server.getCommands().getDispatcher();
@@ -317,8 +322,9 @@ public abstract class Utils {
 				dispatcher.execute(
 						Utils.formatPlaceholders(command, player, pokemon, price),
 						Hunt.server.createCommandSourceStack());
-			} catch (CommandSyntaxException ex) {
-				throw new RuntimeException(ex);
+			} catch (Exception ex) {
+				Hunt.LOGGER.error("Error running command: " + command);
+				Hunt.LOGGER.error(ex.getMessage());
 			}
 		}
 	}


### PR DESCRIPTION
Having the command list of the reward section in config empty would sometimes crash the server, and having a command that did not exist would fully crash the server. This commit fixes it by checking if the commands list is not null and instead of throwing an exception when it wasn't null but the command didn't exist, it prints the exception without crashing.